### PR TITLE
Include help for Add Game to show how 4 and 5 player games are entered

### DIFF
--- a/static/css/addgame.css
+++ b/static/css/addgame.css
@@ -17,3 +17,11 @@
 	width:29%;
 	float:right;
 }
+.player5help {
+    display: inline-block;
+    font-size: 0.8em
+}
+.player4help {
+    display: none;
+    font-size: 0.8em
+}

--- a/static/js/gameeditor.js
+++ b/static/js/gameeditor.js
@@ -9,18 +9,40 @@ $(function () {
 		if(typeof window.populatedEditor === "function")
 			window.populatedEditor();
 	});
+        function updateTotal() {
+	    var total = getTotalPoints();
+	    var last3 = total % 1000;
+	    $(message).text("Total: " + 
+			    (total < 1000 ? total : 
+			     Math.floor(total / 1000) + "," +
+			     (last3 < 10 ? "00" : last3 < 100 ? "0" : "") +
+			     last3));
+	    return total;
+	}
+    function updateHelp() {
+	$(".player5help").each(function (index, elem) {
+	    elem.style.display = $("#players .playerpoints").length == 4 ? "inline-block" : "none"
+	});
+	$(".player4help").each(function (index, elem) {
+	    elem.style.display = $("#players .playerpoints").length == 5 ? "inline-block" : "none"
+	});
+    }
 	function pointsChange(e) {
-		var total = getTotalPoints();
-		$(message).text("Total: " + total);
+	    var total = updateTotal();
 
-		if(total > 25000 * 4 && $("#players .playerpoints").length == 4)
-			addPlayers();
-		else if(total === 25000 * 4 && $("#players .playerpoints").length == 5)
-			$("#players .player:last-child").last().remove();
+	    if(total > 25000 * 4 && $("#players .playerpoints").length == 4) {
+		addPlayers();
+		updateHelp();
+	    }
+	    else if(total === 25000 * 4 && $("#players .playerpoints").length == 5) {
+		$("#players .player:last-child").last().remove();
+		updateTotal();
+		updateHelp();
+	    }
 
-		var complete = gameComplete(total);
-		if(complete && e.keyCode === 13)
-			$("#submit").click();
+	    var complete = gameComplete(total);
+	    if(complete && e.keyCode === 13)
+		$("#submit").click();
 	}
 	function gameComplete(total) {
 		var playersSelected = true;

--- a/templates/addgame.html
+++ b/templates/addgame.html
@@ -11,4 +11,8 @@
 	<div id="players">
 	</div>
 	<button id="submit" disabled>Add</button>
+	<p class="player5help">When scores total more than 100,000,
+	  a fifth player position will be added.</p>
+	<p class="player4help">When scores total exactly 100,000,
+	  the fifth player position will be removed.</p>
 {% end %}


### PR DESCRIPTION
This commit adds some help text at the bottom of the Add Game screen to
explain how to change to 5-player mode and back to 4-player mode. It
also fixes a bug where the total score was not updated immediately after
deleting the 5th player.  The help text is updated dynamically depending
on the current mode.

This change also adds a thousands separator comma to the point total.