### PR TITLE
Fix use of map in seating.py to avoid problem in Python 3

### DIFF
--- a/seating.py
+++ b/seating.py
@@ -19,7 +19,7 @@ class RegenTables(tornado.web.RequestHandler):
         with db.getCur() as cur:
             cur.execute("SELECT PlayerId, Priority FROM CurrentPlayers")
             rows = cur.fetchall()
-            players = map(lambda x: x[0], rows)
+            players = list(map(lambda x: x[0], rows))
             numplayers = len(players)
             priorities = dict(rows)
             playergames = playerGames(players, cur)
@@ -109,7 +109,7 @@ class PlayersList(tornado.web.RequestHandler):
         with db.getCur() as cur:
             self.set_header('Content-Type', 'application/json')
             cur.execute("SELECT Name FROM Players ORDER BY Name")
-            self.write(json.dumps(map(lambda x:x[0], cur.fetchall())))
+            self.write(json.dumps(list(map(lambda x:x[0], cur.fetchall()))))
 
 POPULATION = 256
 


### PR DESCRIPTION
The `map` function behaves slightly differently in Python 2 vs 3.  In
Python 2, it returns a sequence, but in Python 3 it can return an map
object/iterator whose length can't be measured and whose elements
can't be sliced.  This change wraps the output of `map` with a `list`
function so the rows fetched from the db are processed like a list.