### PR TITLE
Fix cookie handling for Python3 so admin and stylesheet cookies work

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
 import tornado.web
 
+def stringify(x):
+    if x is None or isinstance(x, str):
+        return x
+    elif isinstance(x, bytes):
+        return x.decode()
+    else:
+        return str(x)
+
 class BaseHandler(tornado.web.RequestHandler):
     def get_current_user(self):
-        return self.get_secure_cookie("user")
+        return stringify(self.get_secure_cookie("user"))
 
     def get_is_admin(self):
-        return self.get_secure_cookie("admin") == "1"
+        return stringify(self.get_secure_cookie("admin")) == "1"
 
     def get_stylesheet(self):
-        return self.get_secure_cookie("stylesheet")
+        return stringify(self.get_secure_cookie("stylesheet"))
 
     def render(self, template_name, **kwargs):
             tornado.web.RequestHandler.render(self,

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ cookie_secret = util.randString(32)
 
 class MainHandler(handler.BaseHandler):
     def get(self):
-        admin = self.get_secure_cookie("admin")
+        admin = handler.stringify(self.get_secure_cookie("admin"))
 
         no_user = False
         with db.getCur() as cur:


### PR DESCRIPTION
The tornado module returns cookie values as byte arrays.  In Python3
byte arrays do not match equivalent strings using the == operator.
This change wraps the calls to get_secure_cookie in a stringify
utility that forces the cookie value to a unicode string if it is not
None or already in string form.  It also adds a logger for "WebServer"
which logs user log in and log out actions.