### PR TITLE
Fix player help after adding a game

### DIFF
--- a/static/js/addgame.js
+++ b/static/js/addgame.js
@@ -5,12 +5,8 @@
 				$("#message").text("GAME ADDED");
 				$("#content").append($("<a href='/addgame' class='button'>ADD ANOTHER</a>"));
 
-			        $(".player5help").each(function (index, elem) {
-				    elem.style.display = "none"
-				});
-			        $(".player4help").each(function (index, elem) {
-				    elem.style.display = "none"
-				});
+			        $(".player5help").remove();
+			        $(".player4help").remove();
 			}, undefined));
 	});
 })(jQuery);

--- a/static/js/addgame.js
+++ b/static/js/addgame.js
@@ -4,6 +4,13 @@
 			"/addgame", function() {
 				$("#message").text("GAME ADDED");
 				$("#content").append($("<a href='/addgame' class='button'>ADD ANOTHER</a>"));
+
+			        $(".player5help").each(function (index, elem) {
+				    elem.style.display = "none"
+				});
+			        $(".player4help").each(function (index, elem) {
+				    elem.style.display = "none"
+				});
 			}, undefined));
 	});
 })(jQuery);

--- a/static/js/gameeditor.js
+++ b/static/js/gameeditor.js
@@ -32,13 +32,12 @@ $(function () {
 
 	    if(total > 25000 * 4 && $("#players .playerpoints").length == 4) {
 		addPlayers();
-		updateHelp();
 	    }
 	    else if(total === 25000 * 4 && $("#players .playerpoints").length == 5) {
 		$("#players .player:last-child").last().remove();
 		updateTotal();
-		updateHelp();
 	    }
+	    updateHelp();
 
 	    var complete = gameComplete(total);
 	    if(complete && e.keyCode === 13)


### PR DESCRIPTION
This fix clears the player help text after adding a new game, and
restores it if another game is added.