### PR TITLE
Make Add Players from Meetup button contingent on meetup configuration

### DIFF
--- a/templates/seating.html
+++ b/templates/seating.html
@@ -9,7 +9,9 @@
 	<input id="person" type="text" class="playercomplete" placeholder="PLAYER"></input>
 	<button id="addperson">ADD</button>
 	<button id="clearplayers">CLEAR</button>
-	<button id="meetup">ADD MEETUP RSVPS</button>
+	{% if meetup_ok %}
+	        <button id="meetup">ADD MEETUP RSVPS FOR {{ today.upper() }}</button>
+	{% end %}
 
 	<div id="key">
 		<div class="player">


### PR DESCRIPTION
For clubs that don't use meetup.com, there's no need for the button
that adds the RSVPs.  This change checks whether the API parameters are
configured or not and only displays the button if they are.  It also
adds today's date to the button label to make it clearer what RSVPs
will be added.