### PR TITLE
Fixed seater to use meetup account name if defined when importing RSVPS

### DIFF
--- a/main.py
+++ b/main.py
@@ -216,7 +216,7 @@ class PlayerStats(handler.BaseHandler):
         with db.getCur() as cur:
             cur.execute("SELECT Id,Name,MeetupName FROM Players WHERE Id = ? OR Name = ?", (player, player))
             player = cur.fetchone()
-            if len(player) == 0:
+            if player is None or len(player) == 0:
                 return self.render("stats.html", error = "Couldn't find that player")
 
             player, name, meetupname = player

--- a/templates/seating.html
+++ b/templates/seating.html
@@ -10,7 +10,7 @@
 	<button id="addperson">ADD</button>
 	<button id="clearplayers">CLEAR</button>
 	{% if meetup_ok %}
-	        <button id="meetup">ADD MEETUP RSVPS FOR {{ today.upper() }}</button>
+	        <button id="meetup">ADD RSVPS FOR {{ today.upper() }} OR NEXT MEETUP</button>
 	{% end %}
 
 	<div id="key">


### PR DESCRIPTION
Improved wording on meetup import button to show it will take the next
upcoming Meetup event if it can't find one for today.

Fixed a bug when PlayerStats is called with a player name that can't
be found.  This can happen after editing a player name in PlayerStats and
then hitting the back button, because that fetches the page again but with
the wrong name.

Also added debugging code to allow looking up past meetup events for
debugging.