### PR TITLE
Use club name from settings

### DIFF
--- a/settings.py.example
+++ b/settings.py.example
@@ -13,6 +13,10 @@ DBFILE = "scores.db"
 #   DROPGAMES is the default number of games a player must complete in a
 #   quarter in order to have the lowest score dropped from the average.
 DROPGAMES = 9
+#   LINKVALIDDAYS is the number of days links for invitations and
+#   password resets should remain valid.  They expire after LINKVALIDDAYS
+#   has passed.
+LINKVALIDDAYS = 7
 
 # MEETUP interface
 #   If the club uses the meetup.com site for players to RSVP for games,

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,7 +3,7 @@
 {% block title %} - Administration {% end %}
 
 {% block head %}
-	<link href="{{ static_url("css/index.css") }}" type="text/css" rel="stylesheet" />
+	<!-- <link href="{{ static_url("css/admin.css") }}" type="text/css" rel="stylesheet" /> -->
 {% end %}
 
 {% block content %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,7 +3,6 @@
 {% block title %} - Administration {% end %}
 
 {% block head %}
-	<!-- <link href="{{ static_url("css/admin.css") }}" type="text/css" rel="stylesheet" /> -->
 {% end %}
 
 {% block content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,10 +1,11 @@
 {% extends "template.html" %}
+{% import settings %}
 {% block content %}
 	{% if no_user %}
 		<p>It appears you've no users. Would you like to create one?</p>
 		<a class="button" href="/setup">SETUP</a>
 	{% end %}
-	<h1>Seattle Mahjong</h1>
+	<h1>{{settings.CLUBNAME}}</h1>
 	{% if current_user %}
 		<a class="button" href="/addgame">ADD GAME</a>
 	{% end %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,7 +3,7 @@
 {% block title %} - Login{% end %}
 
 {% block head %}
-		<link href="{{ static_url("css/login.css") }}" type="text/css" rel="stylesheet" />
+	<!-- <link href="{{ static_url("css/login.css") }}" type="text/css" rel="stylesheet" /> -->
 {% end %}
 
 {% block content %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,7 +3,6 @@
 {% block title %} - Login{% end %}
 
 {% block head %}
-	<!-- <link href="{{ static_url("css/login.css") }}" type="text/css" rel="stylesheet" /> -->
 {% end %}
 
 {% block content %}

--- a/templates/template.html
+++ b/templates/template.html
@@ -1,7 +1,8 @@
 <!doctype html>
+{% import settings %}
 <html>
 	<head>
-		<title>Seattle Mahjong{% block title %}{% end %}</title>
+		<title>{{settings.CLUBNAME}} {% block title %}{% end %}</title>
 
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width = device-width, initial-scale = 1.0, user-scalable=no" />


### PR DESCRIPTION
This change updates the templates and email content to use the CLUBNAME parameter in settings.py for the club name.  The expiration interval of invites and password reset links is now a parameter in settings.py.

This PR changes the invite and verify mechanisms to avoid extending invitations for or creating duplicate accounts.  When verifying invites, expired links get a different message from duplicates, and both conditions delete the link ID.  There were also a few corrections to the wording of the email messages.