### PR TITLE
Sort game by most recent first in Game History

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,7 +71,8 @@ class HistoryHandler(handler.BaseHandler):
                             " FROM Scores INNER JOIN Players ON"
                             "   Players.Id = Scores.PlayerId"
                             " WHERE Scores.Date BETWEEN ? AND ?"
-                            " GROUP BY Scores.Id ORDER BY Scores.Date DESC;",
+                            " GROUP BY Scores.Id"
+                            " ORDER BY Scores.Date DESC, Scores.GameId DESC;",
                             (dates[min(page * PERPAGE + PERPAGE - 1,
                                        gamecount - 1)][0],
                              dates[min(page * PERPAGE, gamecount - 1)][0]))


### PR DESCRIPTION
By putting the most recent game first, when users click View Game
History after entering game scores, they get to see the game they
just entered on top, instead of scrolling through all of that day's
games to find it.