### PR TITLE
Update beautify.sh to accept specific files on command line

### DIFF
--- a/beautify.sh
+++ b/beautify.sh
@@ -1,3 +1,12 @@
 #!/bin/sh
 
-js-beautify -tnprb end-expand static/js/*
+if [ $# -eq 0 ] ; then
+    for f in static/js/*.js ; do
+	js-beautify -tnr --brace-style=end-expand $f
+    done
+else
+    for f in $* ; do
+	js-beautify -tnr --brace-style=end-expand $f
+    done
+fi
+

--- a/beautify.sh
+++ b/beautify.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 
 if [ $# -eq 0 ] ; then
-    for f in static/js/*.js ; do
-	js-beautify -tnr --brace-style=end-expand $f
-    done
+	js-beautify -tnr --brace-style=end-expand static/js/*.js
 else
-    for f in $* ; do
-	js-beautify -tnr --brace-style=end-expand $f
-    done
+	js-beautify -tnr --brace-style=end-expand $*
 fi
 


### PR DESCRIPTION
Allow beautify.sh to operate on specific files or every javascript
file in the static/js directory.  Also change the command line
syntax so it works with both the python and node.js versions of
js-beautify.  NOTE: this requires dropping the -p argument to
js-beautify which is not documented in the command line help and
is only accepted by the node.js version of js-beautify.  I am
not sure what the -p flag is supposed to do.